### PR TITLE
Improve backend error handling

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -23,6 +23,18 @@ exports.handler = async (event) => {
 
   // Retrieve OpenWeather API key from Lambda environment variables
   const APIKEY = process.env.OPENWEATHER_APIKEY;
+  if (!APIKEY) {
+    return {
+      statusCode: 500,
+      headers: {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Headers": "Content-Type",
+        "Access-Control-Allow-Methods": "OPTIONS,GET"
+      },
+      body: JSON.stringify({ error: "Missing OPENWEATHER_APIKEY" })
+    };
+  }
+
   let statusCode = 200;
   let responseBody = {};
 
@@ -42,6 +54,7 @@ exports.handler = async (event) => {
         `&limit=${limit || 5}&appid=${APIKEY}`;
       console.log("🌐 Geo Direct URL:", apiUrl);
       const openRes = await fetch(apiUrl);
+      if (!openRes.ok) throw new Error(openRes.statusText);
       responseBody = await openRes.json();
     }
 
@@ -54,6 +67,7 @@ exports.handler = async (event) => {
         `&limit=${limit || 1}&appid=${APIKEY}`;
       console.log("🌐 Geo Reverse URL:", apiUrl);
       const openRes = await fetch(apiUrl);
+      if (!openRes.ok) throw new Error(openRes.statusText);
       responseBody = await openRes.json();
     }
 
@@ -68,6 +82,7 @@ exports.handler = async (event) => {
         const geoRes = await fetch(
           `https://api.openweathermap.org/geo/1.0/direct?q=${encodeURIComponent(city)}&limit=1&appid=${APIKEY}`
         );
+        if (!geoRes.ok) throw new Error(geoRes.statusText);
         const geoData = await geoRes.json();
         if (!geoData.length) throw new Error("City not found");
         latitude = geoData[0].lat;
@@ -84,6 +99,7 @@ exports.handler = async (event) => {
       console.log("🌐 Air Pollution URL:", apiUrl);
 
       const openRes = await fetch(apiUrl);
+      if (!openRes.ok) throw new Error(openRes.statusText);
       const aqiPayload = await openRes.json();
       console.log("✅ OpenWeather response:", aqiPayload);
 

--- a/backend/tests/index.test.js
+++ b/backend/tests/index.test.js
@@ -11,6 +11,7 @@ describe('handler /geo/direct', () => {
 
   test('returns data for valid q parameter', async () => {
     global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
       json: jest.fn().mockResolvedValue([{ name: 'London' }])
     });
     const event = { resource: '/geo/direct', queryStringParameters: { q: 'London' } };
@@ -24,5 +25,21 @@ describe('handler /geo/direct', () => {
     const res = await handler(event);
     expect(res.statusCode).toBe(400);
     expect(JSON.parse(res.body).error).toMatch(/Missing 'q' parameter/);
+  });
+
+  test('returns 500 when API key missing', async () => {
+    delete process.env.OPENWEATHER_APIKEY;
+    const event = { resource: '/geo/direct', queryStringParameters: { q: 'London' } };
+    const res = await handler(event);
+    expect(res.statusCode).toBe(500);
+    expect(JSON.parse(res.body).error).toMatch(/OPENWEATHER_APIKEY/);
+  });
+
+  test('returns error when OpenWeather responds with failure', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false, statusText: 'Bad Request', json: jest.fn() });
+    const event = { resource: '/geo/direct', queryStringParameters: { q: 'Paris' } };
+    const res = await handler(event);
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/Bad Request/);
   });
 });


### PR DESCRIPTION
## Summary
- ensure `OPENWEATHER_APIKEY` is required
- throw an error when OpenWeather responses are not `ok`
- add unit tests for the new error cases

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_683f6e92bbb48331b3dd928da6066e4c