### PR TITLE
Add backend endpoint tests

### DIFF
--- a/backend/tests/index.test.js
+++ b/backend/tests/index.test.js
@@ -1,3 +1,11 @@
+const mockSend = jest.fn();
+
+jest.mock('@aws-sdk/lib-dynamodb', () => ({
+  DynamoDBDocumentClient: { from: () => ({ send: mockSend }) },
+  PutCommand: jest.fn(),
+  QueryCommand: jest.fn()
+}));
+
 const { handler } = require('../index');
 
 describe('handler /geo/direct', () => {
@@ -24,5 +32,92 @@ describe('handler /geo/direct', () => {
     const res = await handler(event);
     expect(res.statusCode).toBe(400);
     expect(JSON.parse(res.body).error).toMatch(/Missing 'q' parameter/);
+  });
+});
+
+describe('handler /geo/reverse', () => {
+  beforeEach(() => {
+    process.env.OPENWEATHER_APIKEY = 'dummy';
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('returns data for valid lat/lon parameters', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      json: jest.fn().mockResolvedValue([{ name: 'Paris' }])
+    });
+    const event = { resource: '/geo/reverse', queryStringParameters: { lat: '1', lon: '2' } };
+    const res = await handler(event);
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual([{ name: 'Paris' }]);
+  });
+
+  test('returns error when lat or lon missing', async () => {
+    const event = { resource: '/geo/reverse', queryStringParameters: { lat: '1' } };
+    const res = await handler(event);
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/Missing 'lat' or 'lon' parameter/);
+  });
+});
+
+describe('handler /air', () => {
+  beforeEach(() => {
+    process.env.OPENWEATHER_APIKEY = 'dummy';
+    process.env.TABLE_NAME = 'AirTable';
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('returns AQI data when city parameter provided', async () => {
+    global.fetch = jest.fn()
+      .mockResolvedValueOnce({ json: jest.fn().mockResolvedValue([{ lat: 10, lon: 20 }]) })
+      .mockResolvedValueOnce({ json: jest.fn().mockResolvedValue({
+        list: [{ main: { aqi: 2 }, components: { pm2_5: 5, pm10: 10 } }]
+      }) });
+
+    const event = { resource: '/air', queryStringParameters: { city: 'Berlin' } };
+    const res = await handler(event);
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.aqi).toBe(2);
+    expect(mockSend).toHaveBeenCalled();
+  });
+
+  test('returns error when required parameters missing', async () => {
+    const event = { resource: '/air', queryStringParameters: {} };
+    const res = await handler(event);
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/Missing 'city' or 'lat'\+'lon'/);
+  });
+});
+
+describe('handler /history', () => {
+  beforeEach(() => {
+    process.env.OPENWEATHER_APIKEY = 'dummy';
+    process.env.TABLE_NAME = 'AirTable';
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('returns history for valid location parameter', async () => {
+    mockSend.mockResolvedValueOnce({ Items: [{ aqi: 1 }] });
+    const event = { resource: '/history', queryStringParameters: { location: '1,2' } };
+    const res = await handler(event);
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.history).toEqual([{ aqi: 1 }]);
+  });
+
+  test('returns error when location parameter missing', async () => {
+    const event = { resource: '/history', queryStringParameters: {} };
+    const res = await handler(event);
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/Missing 'location' parameter/);
   });
 });


### PR DESCRIPTION
## Summary
- extend Jest test suite
- add mocked DynamoDB interactions
- cover /geo/reverse, /air, and /history endpoints

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f6e9856848331abe308b681d8ea4d