### PR TITLE
Fix history retrieval with location rounding

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -93,6 +93,11 @@ exports.handler = async (event) => {
         longitude = lon;
       }
 
+      // Normalize coordinates to 2 decimal places so repeated geolocation
+      // queries map to the same DynamoDB partition key even with GPS drift
+      latitude = Number(parseFloat(latitude).toFixed(2));
+      longitude = Number(parseFloat(longitude).toFixed(2));
+
       // Call OpenWeather Air Pollution API
       const apiUrl =
         `https://api.openweathermap.org/data/2.5/air_pollution?lat=${latitude}&lon=${longitude}&appid=${APIKEY}`;
@@ -171,7 +176,8 @@ exports.handler = async (event) => {
             ExpressionAttributeValues: {
               ":locValue": location
             },
-            ScanIndexForward: true // Ascending order (oldest to newest)
+            ScanIndexForward: true, // Ascending order (oldest to newest)
+            ConsistentRead: true
           })
         );
         items = result.Items || [];

--- a/backend/tests/index.test.js
+++ b/backend/tests/index.test.js
@@ -63,6 +63,7 @@ describe('handler /geo/reverse', () => {
 
   test('returns data for valid lat/lon parameters', async () => {
     global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
       json: jest.fn().mockResolvedValue([{ name: 'Paris' }])
     });
     const event = { resource: '/geo/reverse', queryStringParameters: { lat: '1', lon: '2' } };
@@ -91,8 +92,8 @@ describe('handler /air', () => {
 
   test('returns AQI data when city parameter provided', async () => {
     global.fetch = jest.fn()
-      .mockResolvedValueOnce({ json: jest.fn().mockResolvedValue([{ lat: 10, lon: 20 }]) })
-      .mockResolvedValueOnce({ json: jest.fn().mockResolvedValue({
+      .mockResolvedValueOnce({ ok: true, json: jest.fn().mockResolvedValue([{ lat: 10, lon: 20 }]) })
+      .mockResolvedValueOnce({ ok: true, json: jest.fn().mockResolvedValue({
         list: [{ main: { aqi: 2 }, components: { pm2_5: 5, pm10: 10 } }]
       }) });
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -103,7 +103,7 @@ async function getCityNameFromCoords(lat, lon) {
       return `${data[0].name}, ${data[0].country}`;
     }
   } catch (e) { }
-  return `Coordonnées : ${lat.toFixed(3)}, ${lon.toFixed(3)}`;
+  return `Coordonnées : ${lat.toFixed(2)}, ${lon.toFixed(2)}`;
 }
 
 // --- Fetch AQI and History for Coordinates ---
@@ -121,8 +121,11 @@ async function fetchAirAndHistory(lat, lon, locationLabel = null) {
       cityLabel = await getCityNameFromCoords(lat, lon);
     }
 
+    const roundedLat = Number(parseFloat(lat).toFixed(2));
+    const roundedLon = Number(parseFloat(lon).toFixed(2));
+
     // 2. Fetch AQI data from backend /air endpoint
-    const airRes = await fetch(`${apiBaseUrl}/air?lat=${lat}&lon=${lon}`);
+    const airRes = await fetch(`${apiBaseUrl}/air?lat=${roundedLat}&lon=${roundedLon}`);
     const airData = await airRes.json();
     if (!airData || airData.error) throw new Error(airData.error || "Donnée AQI indisponible");
     const aqi = airData.aqi;
@@ -137,7 +140,7 @@ async function fetchAirAndHistory(lat, lon, locationLabel = null) {
     showResult(true);
 
     // 4. Fetch AQI history from backend /history endpoint (last 5 entries)
-    const histRes = await fetch(`${apiBaseUrl}/history?location=${encodeURIComponent(lat + "," + lon)}`);
+    const histRes = await fetch(`${apiBaseUrl}/history?location=${encodeURIComponent(roundedLat + "," + roundedLon)}`);
     const histData = await histRes.json();
     if (histData.history && histData.history.length) {
       const sorted = histData.history.sort((a, b) =>


### PR DESCRIPTION
## Summary
- normalize coordinates to 2 decimals and use consistent reads when querying DynamoDB
- query history with the same rounded coordinates
- update frontend display text

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_683f73f01048833180d75545249c3f89