### PR TITLE
Fix /history issue and enforce English results

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -53,7 +53,9 @@ exports.handler = async (event) => {
         `https://api.openweathermap.org/geo/1.0/direct?q=${encodeURIComponent(q)}` +
         `&limit=${limit || 5}&lang=en&appid=${APIKEY}`;
       console.log("🌐 Geo Direct URL:", apiUrl);
-      const openRes = await fetch(apiUrl);
+      const openRes = await fetch(apiUrl, {
+        headers: { 'Accept-Language': 'en' }
+      });
       if (!openRes.ok) throw new Error(openRes.statusText);
       responseBody = await openRes.json();
     }
@@ -66,7 +68,9 @@ exports.handler = async (event) => {
         `https://api.openweathermap.org/geo/1.0/reverse?lat=${lat}&lon=${lon}` +
         `&limit=${limit || 1}&lang=en&appid=${APIKEY}`;
       console.log("🌐 Geo Reverse URL:", apiUrl);
-      const openRes = await fetch(apiUrl);
+      const openRes = await fetch(apiUrl, {
+        headers: { 'Accept-Language': 'en' }
+      });
       if (!openRes.ok) throw new Error(openRes.statusText);
       responseBody = await openRes.json();
     }
@@ -80,7 +84,8 @@ exports.handler = async (event) => {
       if (city) {
         console.log("📍 Looking up city:", city);
         const geoRes = await fetch(
-          `https://api.openweathermap.org/geo/1.0/direct?q=${encodeURIComponent(city)}&limit=1&lang=en&appid=${APIKEY}`
+          `https://api.openweathermap.org/geo/1.0/direct?q=${encodeURIComponent(city)}&limit=1&lang=en&appid=${APIKEY}`,
+          { headers: { 'Accept-Language': 'en' } }
         );
         if (!geoRes.ok) throw new Error(geoRes.statusText);
         const geoData = await geoRes.json();
@@ -103,7 +108,9 @@ exports.handler = async (event) => {
         `https://api.openweathermap.org/data/2.5/air_pollution?lat=${latitude}&lon=${longitude}&lang=en&appid=${APIKEY}`;
       console.log("🌐 Air Pollution URL:", apiUrl);
 
-      const openRes = await fetch(apiUrl);
+      const openRes = await fetch(apiUrl, {
+        headers: { 'Accept-Language': 'en' }
+      });
       if (!openRes.ok) throw new Error(openRes.statusText);
       const aqiPayload = await openRes.json();
       console.log("✅ OpenWeather response:", aqiPayload);

--- a/backend/tests/index.test.js
+++ b/backend/tests/index.test.js
@@ -26,6 +26,7 @@ describe('handler /geo/direct', () => {
     const res = await handler(event);
     expect(res.statusCode).toBe(200);
     expect(JSON.parse(res.body)).toEqual([{ name: 'London' }]);
+    expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining('lang=en'), expect.objectContaining({ headers: { 'Accept-Language': 'en' } }));
   });
 
   test('returns error when q parameter missing', async () => {
@@ -70,6 +71,7 @@ describe('handler /geo/reverse', () => {
     const res = await handler(event);
     expect(res.statusCode).toBe(200);
     expect(JSON.parse(res.body)).toEqual([{ name: 'Paris' }]);
+    expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining('lang=en'), expect.objectContaining({ headers: { 'Accept-Language': 'en' } }));
   });
 
   test('returns error when lat or lon missing', async () => {
@@ -103,6 +105,8 @@ describe('handler /air', () => {
     const body = JSON.parse(res.body);
     expect(body.aqi).toBe(2);
     expect(mockSend).toHaveBeenCalled();
+    expect(global.fetch).toHaveBeenNthCalledWith(1, expect.stringContaining('lang=en'), expect.objectContaining({ headers: { 'Accept-Language': 'en' } }));
+    expect(global.fetch).toHaveBeenNthCalledWith(2, expect.stringContaining('lang=en'), expect.objectContaining({ headers: { 'Accept-Language': 'en' } }));
   });
 
   test('returns error when required parameters missing', async () => {


### PR DESCRIPTION
## Summary
- send `Accept-Language: en` header to all OpenWeather requests
- test that backend forces English in API calls

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_683f7d653c108331a92af4c047ceb3d2