### PR TITLE
Improve city name translation handling

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -68,9 +68,10 @@ cityInput.addEventListener('input', () => {
       if (!data.length) return;
 
       // Renders suggestions as clickable <li> elements
-      citySuggestions.innerHTML = data.map(city =>
-        `<li class="p-2 hover:bg-indigo-100 cursor-pointer">${city.name}${city.state ? ', ' + city.state : ''}, ${city.country}</li>`
-      ).join('');
+      citySuggestions.innerHTML = data.map(city => {
+        const label = city.local_names && city.local_names.en ? city.local_names.en : city.name;
+        return `<li class="p-2 hover:bg-indigo-100 cursor-pointer">${label}${city.state ? ', ' + city.state : ''}, ${city.country}</li>`;
+      }).join('');
       citySuggestions.classList.remove('hidden');
 
       // Click on a suggestion fills the input and hides the dropdown
@@ -100,7 +101,8 @@ async function getCityNameFromCoords(lat, lon) {
     const res = await fetch(`${apiBaseUrl}/geo/reverse?lat=${lat}&lon=${lon}&limit=1`);
     const data = await res.json();
     if (data && data[0]) {
-      return `${data[0].name}, ${data[0].country}`;
+      const name = data[0].local_names && data[0].local_names.en ? data[0].local_names.en : data[0].name;
+      return `${name}, ${data[0].country}`;
     }
   } catch (e) { }
   return `Coordinates: ${lat.toFixed(2)}, ${lon.toFixed(2)}`;
@@ -182,9 +184,10 @@ async function fetchAirByCity(city) {
     const geoRes = await fetch(`${apiBaseUrl}/geo/direct?q=${encodeURIComponent(city)}&limit=1`);
     const geoData = await geoRes.json();
     if (!geoData.length) throw new Error("City not found.");
-    const { lat, lon, name, country } = geoData[0];
+    const { lat, lon, name, country, local_names } = geoData[0];
+    const label = local_names && local_names.en ? local_names.en : name;
     // Fetch AQI and history for those coordinates
-    await fetchAirAndHistory(lat, lon, `${name}, ${country}`);
+    await fetchAirAndHistory(lat, lon, `${label}, ${country}`);
   } catch (err) {
     showError("Error: " + err.message);
     showResult(false);


### PR DESCRIPTION
## Summary
- prefer `local_names.en` for english labels in autocomplete
- use English translation when determining city name from coordinates
- ensure city lookups show english name if available

## Testing
- `npm test --silent | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_683f9ddf90508331baa6a9ef9440ee32