### PR TITLE
Add configurable API base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ AirCare/
 ├── assets1/ # Images & diagrams  
 │   └── diagramme.png  
 ├── backend/ # Lambda source code  
-├── frontend/ # HTML/CSS/JavaScript  
+├── frontend/ # HTML/CSS/JavaScript (app.js, config.js, index.html)
 ├── .github/workflows/ # CI/CD with GitHub Actions  
 ├── README.md # This file
 
@@ -154,9 +154,16 @@ AirCare/
    ```bash
    npx http-server frontend -c-1
    ```
-   Then open `http://localhost:8080` in your browser. You can edit
-   `frontend/app.js` to point `apiBaseUrl` to your own API Gateway endpoint
-   if needed.
+   Then open `http://localhost:8080` in your browser. To point the frontend to a
+   different API Gateway, update the `API_BASE_URL` value in
+   `frontend/config.js`. No application code changes are required.
+
+### Changing the API endpoint
+
+The `frontend/config.js` file contains the `API_BASE_URL` constant used by the
+frontend. Update this value if you deploy your own backend or API Gateway
+endpoint. Because the frontend imports the value at runtime, you don't need to
+modify any JavaScript logic.
 
 ---
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,7 +1,9 @@
 // === AirCare Frontend Main Script ===
 
-// API base URL (pointing to the deployed AWS API Gateway endpoint)
-const apiBaseUrl = "https://i5x97gj43e.execute-api.ca-central-1.amazonaws.com/prod";
+// API base URL is provided by config.js so deployments can change the
+// backend endpoint without modifying this file.
+import { API_BASE_URL } from './config.js';
+const apiBaseUrl = API_BASE_URL;
 
 // --- DOM elements ---
 const fetchBtn = document.getElementById('fetchBtn');

--- a/frontend/config.js
+++ b/frontend/config.js
@@ -1,0 +1,1 @@
+export const API_BASE_URL = "https://i5x97gj43e.execute-api.ca-central-1.amazonaws.com/prod";

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -68,6 +68,6 @@
     </div>
   </div>
   <!-- Main JavaScript file for frontend logic -->
-  <script src="app.js"></script>
+  <script type="module" src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- allow overriding the API base URL via `frontend/config.js`
- load the new config in `app.js`
- update HTML to use ES modules
- document how to change the endpoint

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f9ddda6188331b30225df78917413