### PR TITLE
Use env variable for API base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,16 +159,21 @@ AirCare/
    ```bash
    npx http-server frontend -c-1
    ```
-   Then open `http://localhost:8080` in your browser. To point the frontend to a
-   different API Gateway, update the `API_BASE_URL` value in
-   `frontend/config.js`. No application code changes are required.
+   Then open `http://localhost:8080` in your browser.
+   The file `frontend/config.js` contains a placeholder string `__API_BASE_URL__`.
+   Before running locally (or during CI deploys), replace this placeholder with
+   your endpoint by setting the `API_BASE_URL` environment variable and
+   running `envsubst` or `sed`.
+   No application code changes are required.
 
 ### Changing the API endpoint
 
-The `frontend/config.js` file contains the `API_BASE_URL` constant used by the
-frontend. Update this value if you deploy your own backend or API Gateway
-endpoint. Because the frontend imports the value at runtime, you don't need to
-modify any JavaScript logic.
+`frontend/config.js` exports a placeholder string `__API_BASE_URL__`. During
+deployment (or before local testing) replace this placeholder with the URL of
+your API Gateway. The recommended approach is to set an `API_BASE_URL`
+environment variable and run `envsubst < frontend/config.js > frontend/config.js`
+or an equivalent `sed` command. The frontend reads the updated value at runtime,
+so you never need to modify the application code.
 
 ---
 

--- a/frontend/config.js
+++ b/frontend/config.js
@@ -1,1 +1,4 @@
-export const API_BASE_URL = "https://i5x97gj43e.execute-api.ca-central-1.amazonaws.com/prod";
+// The value below is replaced during deployment. CI/CD pipelines can
+// substitute `__API_BASE_URL__` with the actual endpoint using a tool
+// like `sed` or `envsubst`.
+export const API_BASE_URL = "__API_BASE_URL__";


### PR DESCRIPTION
## Summary
- make `frontend/config.js` use a placeholder API url
- document API_BASE_URL replacement in README

## Testing
- `npm ci` in `backend`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68406d3198b483319146a16835c229ad