### PR TITLE
Update test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,19 @@ AirCare/
    ```bash
    export TABLE_NAME=AirCareHistoryAQI
    ```
+
+### Install dependencies before running tests
+
+Make sure all Node.js dependencies are installed in the `backend/` folder:
+
+```bash
+cd backend
+npm install
+```
+
+For CI environments, include `npm ci` in your setup script so tests run with the
+correct dependencies.
+
 5. Run the backend test suite to ensure everything works:
    ```bash
    npm test


### PR DESCRIPTION
## Summary
- warn developers to run `npm install` before tests or use `npm ci`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68406d48d44083319b76a8d011914914