### PR TITLE
Add dark mode UI toggle

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -19,6 +19,7 @@ const recommendation = document.getElementById('recommendation');
 const emojiDisplay = document.getElementById('emoji');
 const historySection = document.getElementById('historySection');
 const historyList = document.getElementById('historyList');
+const themeToggle = document.getElementById('themeToggle');
 
 // Used for debouncing autocomplete requests
 let debounceTimeout = null;
@@ -50,6 +51,27 @@ function showError(msg = "") {
 // Shows or hides the AQI history section
 function showHistory(show) {
   historySection.classList.toggle('hidden', !show);
+}
+
+// --- Theme toggle ---
+function setTheme(mode) {
+  if (mode === 'dark') {
+    document.documentElement.classList.add('dark');
+    themeToggle.textContent = '☀️';
+  } else {
+    document.documentElement.classList.remove('dark');
+    themeToggle.textContent = '🌙';
+  }
+  localStorage.setItem('theme', mode);
+}
+
+if (themeToggle) {
+  themeToggle.addEventListener('click', () => {
+    const isDark = document.documentElement.classList.contains('dark');
+    setTheme(isDark ? 'light' : 'dark');
+  });
+  const saved = localStorage.getItem('theme');
+  if (saved === 'dark') setTheme('dark');
 }
 
 // --- City Autocomplete Logic ---

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,13 +9,16 @@
   <!-- Optionally add your own custom CSS -->
   <link rel="stylesheet" href="style.css" />
 </head>
-<body class="bg-gradient-to-br from-blue-100 to-indigo-200 min-h-screen flex flex-col items-center justify-center text-gray-800 font-sans transition-all duration-700 px-2">
+<body class="bg-gradient-to-br from-blue-100 to-indigo-200 dark:from-gray-900 dark:to-gray-800 min-h-screen flex flex-col items-center justify-center text-gray-800 dark:text-gray-200 font-sans transition-all duration-700 px-2">
   <!-- Main container for the app -->
-  <div class="w-full max-w-md md:max-w-lg p-6 bg-white shadow-2xl rounded-2xl relative mx-auto">
-    <!-- Application title with emoji -->
-    <h1 class="text-3xl font-bold text-center mb-4 flex items-center justify-center gap-2">
-      <span>🌿</span> AirCare
-    </h1>
+  <div class="w-full max-w-md md:max-w-lg p-6 bg-white dark:bg-gray-700 shadow-2xl rounded-2xl relative mx-auto">
+    <!-- Header with title and dark mode toggle -->
+    <div class="flex items-center justify-between mb-4">
+      <h1 class="text-3xl font-bold flex items-center gap-2">
+        <span>🌿</span> AirCare
+      </h1>
+      <button id="themeToggle" class="text-2xl" aria-label="Toggle dark mode">🌙</button>
+    </div>
 
     <!-- City selection and geolocation controls -->
     <div class="mb-4 flex flex-col gap-2 relative">

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -8,6 +8,11 @@
   animation: spin 1s linear infinite; /* Infinite rotation animation */
 }
 
+.dark .loader {
+  border-color: #4b5563;             /* Darker ring in dark mode */
+  border-top-color: #a5b4fc;         /* Softer indigo spin */
+}
+
 @keyframes spin {
   to { transform: rotate(360deg); }   /* Full circle rotation */
 }
@@ -19,6 +24,12 @@
   box-shadow: 0 4px 16px 0 #0001;     /* Soft drop shadow for floating effect */
 }
 
+.dark #citySuggestions {
+  background: #374151;                /* Gray background in dark mode */
+  border-color: #4b5563;
+  color: #f9fafb;
+}
+
 #citySuggestions li {
   padding: 0.5rem 1rem;               /* Spacing for each suggestion */
   cursor: pointer;                    /* Pointer cursor on hover */
@@ -28,6 +39,11 @@
 #citySuggestions li:hover,
 #citySuggestions .active {
   background: #eef2ff;                /* Highlight on hover or active */
+}
+
+.dark #citySuggestions li:hover,
+.dark #citySuggestions .active {
+  background: #4b5563;
 }
 
 /* Smooth fade-in for result and history sections */


### PR DESCRIPTION
## Summary
- integrate dark mode toggle into frontend
- style autocomplete and loader for dark mode

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6840876f85388331a808e43b90cb53f4