### PR TITLE
Improve dark mode detection

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -107,10 +107,16 @@ function setTheme(mode) {
 
 function initTheme() {
   const saved = localStorage.getItem('theme');
-  if (saved) {
+  if (saved === 'light' || saved === 'dark') {
     applyTheme(saved);
-  } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-    applyTheme('dark');
+  } else {
+    const system = window.matchMedia('(prefers-color-scheme: dark)');
+    applyTheme(system.matches ? 'dark' : 'light');
+    system.addEventListener('change', (e) => {
+      if (!localStorage.getItem('theme')) {
+        applyTheme(e.matches ? 'dark' : 'light');
+      }
+    });
   }
 }
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,7 +7,11 @@
   <title>AirCare - Air Quality</title>
   <script>
     const savedTheme = localStorage.getItem('theme');
-    if (savedTheme === 'dark' || (!savedTheme && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+    if (savedTheme === 'light') {
+      document.documentElement.classList.remove('dark');
+    } else if (savedTheme === 'dark') {
+      document.documentElement.classList.add('dark');
+    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
       document.documentElement.classList.add('dark');
     }
   </script>


### PR DESCRIPTION
## Summary
- ensure theme initialization reacts to system preference
- update early dark-mode script in HTML

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841017e656c83318353da8775269100