### PR TITLE
Fix dark mode persistence when localStorage unavailable

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -102,18 +102,27 @@ function applyTheme(mode) {
 
 function setTheme(mode) {
   applyTheme(mode);
-  localStorage.setItem('theme', mode);
+  try {
+    localStorage.setItem('theme', mode);
+  } catch (_) {}
 }
 
 function initTheme() {
-  const saved = localStorage.getItem('theme');
+  let saved = null;
+  try {
+    saved = localStorage.getItem('theme');
+  } catch (_) {}
   if (saved === 'light' || saved === 'dark') {
     applyTheme(saved);
   } else {
     const system = window.matchMedia('(prefers-color-scheme: dark)');
     applyTheme(system.matches ? 'dark' : 'light');
     system.addEventListener('change', (e) => {
-      if (!localStorage.getItem('theme')) {
+      try {
+        if (!localStorage.getItem('theme')) {
+          applyTheme(e.matches ? 'dark' : 'light');
+        }
+      } catch (_) {
         applyTheme(e.matches ? 'dark' : 'light');
       }
     });

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,13 +6,19 @@
   <meta name="color-scheme" content="light dark" />
   <title>AirCare - Air Quality</title>
   <script>
-    const savedTheme = localStorage.getItem('theme');
-    if (savedTheme === 'light') {
-      document.documentElement.classList.remove('dark');
-    } else if (savedTheme === 'dark') {
-      document.documentElement.classList.add('dark');
-    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-      document.documentElement.classList.add('dark');
+    try {
+      const savedTheme = localStorage.getItem('theme');
+      if (savedTheme === 'light') {
+        document.documentElement.classList.remove('dark');
+      } else if (savedTheme === 'dark') {
+        document.documentElement.classList.add('dark');
+      } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+        document.documentElement.classList.add('dark');
+      }
+    } catch (err) {
+      if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+        document.documentElement.classList.add('dark');
+      }
     }
   </script>
   <!-- Import Tailwind CSS from CDN and enable class-based dark mode -->


### PR DESCRIPTION
## Summary
- handle localStorage errors when reading/saving theme
- fallback to system theme if localStorage is blocked

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684102b4b02c8331af7b0693dd7b94d0