### PR TITLE
Fix dark mode persistence

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -100,18 +100,34 @@ function applyTheme(mode) {
   themeToggle.textContent = mode === 'dark' ? '☀️' : '🌙';
 }
 
+function setCookie(name, value, days) {
+  document.cookie = `${name}=${value}; path=/; max-age=${days * 86400}`;
+}
+
+function getCookie(name) {
+  const m = document.cookie.match(new RegExp('(?:^|; )' + name + '=([^;]*)'));
+  return m ? m[1] : null;
+}
+
 function setTheme(mode) {
   applyTheme(mode);
   try {
     localStorage.setItem('theme', mode);
-  } catch (_) {}
+  } catch (_) {
+    setCookie('theme', mode, 365);
+  }
 }
 
 function initTheme() {
   let saved = null;
   try {
     saved = localStorage.getItem('theme');
-  } catch (_) {}
+  } catch (_) {
+    saved = getCookie('theme');
+  }
+  if (!saved) {
+    saved = getCookie('theme');
+  }
   if (saved === 'light' || saved === 'dark') {
     applyTheme(saved);
   } else {
@@ -119,11 +135,13 @@ function initTheme() {
     applyTheme(system.matches ? 'dark' : 'light');
     system.addEventListener('change', (e) => {
       try {
-        if (!localStorage.getItem('theme')) {
+        if (!localStorage.getItem('theme') && !getCookie('theme')) {
           applyTheme(e.matches ? 'dark' : 'light');
         }
       } catch (_) {
-        applyTheme(e.matches ? 'dark' : 'light');
+        if (!getCookie('theme')) {
+          applyTheme(e.matches ? 'dark' : 'light');
+        }
       }
     });
   }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,8 +6,12 @@
   <meta name="color-scheme" content="light dark" />
   <title>AirCare - Air Quality</title>
   <script>
+    function getCookie(name) {
+      const m = document.cookie.match(new RegExp('(?:^|; )' + name + '=([^;]*)'));
+      return m ? m[1] : null;
+    }
     try {
-      const savedTheme = localStorage.getItem('theme');
+      const savedTheme = localStorage.getItem('theme') || getCookie('theme');
       if (savedTheme === 'light') {
         document.documentElement.classList.remove('dark');
       } else if (savedTheme === 'dark') {
@@ -16,7 +20,8 @@
         document.documentElement.classList.add('dark');
       }
     } catch (err) {
-      if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      const savedTheme = getCookie('theme');
+      if (savedTheme === 'dark' || (!savedTheme && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
         document.documentElement.classList.add('dark');
       }
     }


### PR DESCRIPTION
## Summary
- add cookie fallback to theme functions
- read theme cookie in initial script

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841044117508331a9afb75cc8b5d999