### PR TITLE
Add Cognito integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,15 @@ AirCare/
    ```bash
    API_BASE_URL=https://your-api-endpoint node scripts/set-api-url.js
    ```
-7. Serve the frontend locally from the project root:
+7. Generate the Cognito configuration for the frontend:
+   ```bash
+   COGNITO_REGION=your-region \
+   COGNITO_USER_POOL_ID=pool-id \
+   COGNITO_USER_POOL_CLIENT_ID=client-id \
+   COGNITO_DOMAIN=your-domain.auth.region.amazoncognito.com \
+   node scripts/set-cognito-config.js
+   ```
+8. Serve the frontend locally from the project root:
    ```bash
    npx http-server frontend -c-1
    ```
@@ -186,7 +194,7 @@ This regenerates `frontend/config.js` with your endpoint. Because the frontend i
 ## 🚧 Upcoming Improvements
 
 - 📊 Build a **QuickSight Dashboard** for AQI trends (from DynamoDB)
-- 👥 Integrate **Amazon Cognito** for user authentication
+- ✅ Integrate **Amazon Cognito** for user authentication
 - 📜 Implement API Gateway **usage plans and throttling**
 
 ---

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -3,6 +3,7 @@
 // API base URL is provided by config.js so deployments can change the
 // backend endpoint without modifying this file.
 import { API_BASE_URL } from './config.js';
+import { signIn, signOut, getCurrentUser } from './auth.js';
 const apiBaseUrl = API_BASE_URL;
 
 // --- DOM elements ---
@@ -20,6 +21,8 @@ const emojiDisplay = document.getElementById('emoji');
 const historySection = document.getElementById('historySection');
 const historyList = document.getElementById('historyList');
 const themeToggle = document.getElementById('themeToggle');
+const loginBtn = document.getElementById('loginBtn');
+const logoutBtn = document.getElementById('logoutBtn');
 
 // Used for debouncing autocomplete requests
 let debounceTimeout = null;
@@ -135,6 +138,27 @@ if (themeToggle) {
     setTheme(isDark ? 'light' : 'dark');
   });
   initTheme();
+}
+
+// --- Cognito Authentication ---
+async function updateAuthUI() {
+  const user = await getCurrentUser();
+  if (user) {
+    loginBtn.classList.add('hidden');
+    logoutBtn.classList.remove('hidden');
+  } else {
+    loginBtn.classList.remove('hidden');
+    logoutBtn.classList.add('hidden');
+  }
+}
+
+if (loginBtn && logoutBtn) {
+  loginBtn.addEventListener('click', () => signIn());
+  logoutBtn.addEventListener('click', async () => {
+    await signOut();
+    updateAuthUI();
+  });
+  updateAuthUI();
 }
 
 // --- City Autocomplete Logic ---

--- a/frontend/auth.js
+++ b/frontend/auth.js
@@ -1,0 +1,27 @@
+import { COGNITO_CONFIG } from './cognito-config.js';
+
+// aws-amplify is loaded globally in index.html as `aws_amplify`
+const { Amplify, Auth } = window.aws_amplify || {};
+
+if (Amplify && Auth) {
+  Amplify.configure(COGNITO_CONFIG);
+}
+
+export async function signIn() {
+  if (Auth) return Auth.federatedSignIn();
+  throw new Error('Amplify not loaded');
+}
+
+export async function signOut() {
+  if (Auth) return Auth.signOut();
+  throw new Error('Amplify not loaded');
+}
+
+export async function getCurrentUser() {
+  if (!Auth) return null;
+  try {
+    return await Auth.currentAuthenticatedUser();
+  } catch {
+    return null;
+  }
+}

--- a/frontend/cognito-config.js
+++ b/frontend/cognito-config.js
@@ -1,0 +1,14 @@
+export const COGNITO_CONFIG = {
+  Auth: {
+    region: "",
+    userPoolId: "",
+    userPoolWebClientId: "",
+    oauth: {
+      domain: "",
+      scope: ["openid", "email"],
+      redirectSignIn: window.location.origin,
+      redirectSignOut: window.location.origin,
+      responseType: "code"
+    }
+  }
+};

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -40,7 +40,11 @@
       <h1 class="text-3xl font-bold flex items-center gap-2">
         <span>🌿</span> AirCare
       </h1>
-      <button id="themeToggle" class="text-2xl transition-colors" aria-label="Toggle dark mode">🌙</button>
+      <div class="flex items-center gap-2">
+        <button id="loginBtn" class="px-2 py-1 bg-indigo-500 text-white rounded hidden">Login</button>
+        <button id="logoutBtn" class="px-2 py-1 bg-indigo-500 text-white rounded hidden">Logout</button>
+        <button id="themeToggle" class="text-2xl transition-colors" aria-label="Toggle dark mode">🌙</button>
+      </div>
     </div>
 
     <!-- City selection and geolocation controls -->
@@ -93,6 +97,8 @@
       <ul id="historyList" class="list-disc list-inside text-sm text-gray-700 dark:text-gray-300"></ul>
     </div>
   </div>
+  <!-- AWS Amplify for Cognito authentication -->
+  <script src="https://unpkg.com/aws-amplify@6/dist/aws-amplify.min.js"></script>
   <!-- Main JavaScript file for frontend logic -->
   <script type="module" src="app.js"></script>
 </body>

--- a/scripts/set-cognito-config.js
+++ b/scripts/set-cognito-config.js
@@ -1,0 +1,27 @@
+const fs = require('fs');
+const path = require('path');
+
+const { COGNITO_REGION, COGNITO_USER_POOL_ID, COGNITO_USER_POOL_CLIENT_ID, COGNITO_DOMAIN } = process.env;
+
+if (!COGNITO_REGION || !COGNITO_USER_POOL_ID || !COGNITO_USER_POOL_CLIENT_ID || !COGNITO_DOMAIN) {
+  console.error('Error: Cognito environment variables not fully set.');
+  process.exit(1);
+}
+
+const configPath = path.join(__dirname, '..', 'frontend', 'cognito-config.js');
+const content = `export const COGNITO_CONFIG = {
+  Auth: {
+    region: "${COGNITO_REGION}",
+    userPoolId: "${COGNITO_USER_POOL_ID}",
+    userPoolWebClientId: "${COGNITO_USER_POOL_CLIENT_ID}",
+    oauth: {
+      domain: "${COGNITO_DOMAIN}",
+      scope: ["openid", "email"],
+      redirectSignIn: window.location.origin,
+      redirectSignOut: window.location.origin,
+      responseType: "code"
+    }
+  }
+};\n`;
+fs.writeFileSync(configPath, content);
+console.log(`Updated ${configPath}`);


### PR DESCRIPTION
## Summary
- generate Cognito config for the frontend via new script
- add login/logout buttons and Amplify setup in the frontend
- integrate Cognito auth helper module
- document Cognito setup steps

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684104ec15d48331885f9ce37ec32c60