### PR TITLE
Fix Amplify CDN path

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -103,7 +103,7 @@
     </div>
   </div>
   <!-- AWS Amplify for Cognito authentication -->
-  <script src="https://unpkg.com/aws-amplify@6/dist/aws-amplify.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/aws-amplify@4.3.46/dist/aws-amplify.min.js"></script>
   <!-- Main JavaScript file for frontend logic -->
   <script type="module" src="app.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- fix the CDN URL for AWS Amplify in `index.html`

## Testing
- `curl -sI https://cdn.jsdelivr.net/npm/aws-amplify@4.3.46/dist/aws-amplify.min.js`

------
https://chatgpt.com/codex/tasks/task_e_6841072c903c83319ec52c8315b49fc3