### PR TITLE
Fix dark mode initialization error

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -10,23 +10,34 @@
       const m = document.cookie.match(new RegExp('(?:^|; )' + name + '=([^;]*)'));
       return m ? m[1] : null;
     }
+
+    function applyInitialTheme(dark) {
+      document.documentElement.classList.toggle('dark', dark);
+      if (document.body) {
+        document.body.classList.toggle('dark', dark);
+      } else {
+        document.addEventListener('DOMContentLoaded', () => {
+          document.body.classList.toggle('dark', dark);
+        });
+      }
+    }
+
     try {
       const savedTheme = localStorage.getItem('theme') || getCookie('theme');
       if (savedTheme === 'light') {
-        document.documentElement.classList.remove('dark');
-        document.body.classList.remove('dark');
+        applyInitialTheme(false);
       } else if (savedTheme === 'dark') {
-        document.documentElement.classList.add('dark');
-        document.body.classList.add('dark');
+        applyInitialTheme(true);
       } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-        document.documentElement.classList.add('dark');
-        document.body.classList.add('dark');
+        applyInitialTheme(true);
       }
     } catch (err) {
       const savedTheme = getCookie('theme');
-      if (savedTheme === 'dark' || (!savedTheme && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
-        document.documentElement.classList.add('dark');
-        document.body.classList.add('dark');
+      if (
+        savedTheme === 'dark' ||
+        (!savedTheme && window.matchMedia('(prefers-color-scheme: dark)').matches)
+      ) {
+        applyInitialTheme(true);
       }
     }
   </script>


### PR DESCRIPTION
## Summary
- avoid referencing `document.body` before it exists
- apply dark-mode class after DOM loads when needed

## Testing
- `npm install` in `backend`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843508c526c8331a74589429555c81c