### PR TITLE
Limit history graph to 10 entries

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -85,9 +85,14 @@ function renderHistory(history) {
       historyList.appendChild(li);
     });
 
-    const asc = history.slice().sort((a, b) => new Date(a.timestamp) - new Date(b.timestamp));
-    const labels = asc.map(item => new Date(item.timestamp).toLocaleString('en-US'));
-    const values = asc.map(item => item.aqi);
+    const asc = history
+      .slice()
+      .sort((a, b) => new Date(a.timestamp) - new Date(b.timestamp));
+    const recent = asc.slice(-10); // keep only the last 10 entries for the graph
+    const labels = recent.map(item =>
+      new Date(item.timestamp).toLocaleString('en-US')
+    );
+    const values = recent.map(item => item.aqi);
 
     if (historyChartEl) {
       if (!historyChart) {


### PR DESCRIPTION
## Summary
- show only the last 10 history points in the Chart.js graph

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_6849c7b47f108331b10f9c6f30510144