### PR TITLE
Improve AQI history styling

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -81,7 +81,12 @@ function renderHistory(history) {
     desc.slice(0, 5).forEach(item => {
       const date = new Date(item.timestamp);
       const li = document.createElement("li");
-      li.textContent = `${date.toLocaleString('en-US')} → AQI ${item.aqi} (${item.advice})`;
+      const info = AQI_MAP[item.aqi - 1];
+      li.className = "flex items-center justify-between border rounded-md p-2 bg-gray-50";
+      li.innerHTML = `
+        <span>${date.toLocaleString('en-US')}</span>
+        <span class="font-medium ${info.color}">${info.emoji} ${info.label} (${item.aqi})</span>
+      `;
       historyList.appendChild(li);
     });
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -72,7 +72,7 @@
     <div id="historySection" class="mt-6 hidden transition-all duration-700">
       <h3 class="text-lg font-semibold mb-2">AQI History</h3>
       <canvas id="historyChart" class="w-full h-48 mb-4"></canvas>
-      <ul id="historyList" class="list-disc list-inside text-sm text-gray-700"></ul>
+      <ul id="historyList" class="text-sm text-gray-700 space-y-2"></ul>
     </div>
   </div>
   <!-- Chart.js for history graph -->


### PR DESCRIPTION
## Summary
- adjust history list container styling
- render AQI history items with badges and colors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849c94df4b48331a6dc3a773607142e