### PR TITLE
Update AWS Amplify version

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -78,7 +78,7 @@
   <!-- Chart.js for history graph -->
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <!-- AWS Amplify for Cognito authentication -->
-  <script src="https://cdn.jsdelivr.net/npm/aws-amplify@4.3.46/dist/aws-amplify.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/aws-amplify@6.15.0/dist/aws-amplify.min.js"></script>
   <!-- Main JavaScript file for frontend logic -->
   <script type="module" src="app.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- update AWS Amplify CDN script tag to v6.15.0

## Testing
- `npx -y http-server frontend -c-1 -p 8080`
- `curl http://localhost:8080/index.html`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a238f03708331bfbed18b468b0c95