### PR TITLE
Handle unknown endpoint with 404

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -201,7 +201,7 @@ exports.handler = async (event) => {
     else if (path.endsWith("/geo/reverse")) data = await handleGeoReverse(params, APIKEY);
     else if (path.endsWith("/air")) data = await handleAir(params, APIKEY);
     else if (path.endsWith("/history")) data = await handleHistory(params);
-    else throw new Error("Unknown endpoint: " + path);
+    else return buildResponse(404, { error: "Unknown endpoint: " + path });
 
     return buildResponse(200, data);
   } catch (err) {

--- a/backend/tests/index.test.js
+++ b/backend/tests/index.test.js
@@ -200,3 +200,16 @@ describe('handler /history', () => {
     expect(JSON.parse(res.body).error).toMatch(/DynamoDB history read failed/);
   });
 });
+
+describe('handler unknown endpoint', () => {
+  beforeEach(() => {
+    process.env.OPENWEATHER_APIKEY = 'dummy';
+  });
+
+  test('returns 404 for invalid path', async () => {
+    const event = { resource: '/invalid', queryStringParameters: {} };
+    const res = await handler(event);
+    expect(res.statusCode).toBe(404);
+    expect(JSON.parse(res.body).error).toMatch(/Unknown endpoint/);
+  });
+});


### PR DESCRIPTION
## Summary
- return a 404 response when the request path doesn't match any handlers
- test that invalid endpoints return 404

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_684b5bdf83688331b87e374f8c224365