### PR TITLE
Fix frontend config generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,17 +182,16 @@ AirCare/
    After adjusting the domain or URLs, rerun the script above to regenerate
    `frontend/cognito-config.js`.
 8. Serve the frontend locally from the project root. The helper script below
-   ensures that `frontend/config.js` exists before launching the server:
+   (re)generates `frontend/config.js` every time so the API endpoint matches
+   the `API_BASE_URL` environment variable:
    ```bash
    node scripts/dev-server.js
    ```
    Then open `http://localhost:8080` in your browser.
 
-### Troubleshooting
-
 - **404 for `config.js`** – run `node scripts/dev-server.js` to start the
-  server. This script automatically creates `frontend/config.js` if it is
-  missing.
+  server. It will regenerate `frontend/config.js` using `API_BASE_URL` so the
+  frontend points to the correct backend.
 - **404 for `chart.umd.js`** – ensure you have an internet connection. The
   Chart.js library is loaded from a CDN (see `frontend/index.html`, line 79).
 ### Changing the API endpoint

--- a/scripts/dev-server.js
+++ b/scripts/dev-server.js
@@ -5,11 +5,10 @@ const path = require('path');
 const rootDir = path.join(__dirname, '..');
 const configPath = path.join(rootDir, 'frontend', 'config.js');
 
-if (!fs.existsSync(configPath)) {
-  const apiUrl = process.env.API_BASE_URL || 'https://your-api-endpoint';
-  const content = `export const API_BASE_URL = "${apiUrl}";\n`;
-  fs.writeFileSync(configPath, content);
-  console.log(`Created ${configPath} with API_BASE_URL=${apiUrl}`);
-}
+// Always generate config.js so the API base URL reflects the environment
+const apiUrl = process.env.API_BASE_URL || 'https://your-api-endpoint';
+const content = `export const API_BASE_URL = "${apiUrl}";\n`;
+fs.writeFileSync(configPath, content);
+console.log(`Generated ${configPath} with API_BASE_URL=${apiUrl}`);
 
 execSync('npx --yes http-server frontend -c-1', { stdio: 'inherit', cwd: rootDir });


### PR DESCRIPTION
## Summary
- always regenerate `frontend/config.js` in `dev-server.js`
- document regenerated config in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c5d7b29ac83318d9193fe6d2e0c22