### PR TITLE
Update API URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ AirCare/
    ```
 6. Set the API endpoint for the frontend:
    ```bash
-   API_BASE_URL=https://your-api-endpoint node scripts/set-api-url.js
+   API_BASE_URL=https://i5x97gj43e.execute-api.ca-central-1.amazonaws.com/prod node scripts/set-api-url.js
    ```
    This creates `frontend/config.js`.
 7. Generate the Cognito configuration for the frontend:

--- a/frontend/config.example.js
+++ b/frontend/config.example.js
@@ -1,1 +1,0 @@
-export const API_BASE_URL = "https://your-api-endpoint";

--- a/frontend/config.js
+++ b/frontend/config.js
@@ -1,1 +1,1 @@
-export const API_BASE_URL = "https://your-api-endpoint";
+export const API_BASE_URL = "https://i5x97gj43e.execute-api.ca-central-1.amazonaws.com/prod";

--- a/scripts/dev-server.js
+++ b/scripts/dev-server.js
@@ -6,7 +6,7 @@ const rootDir = path.join(__dirname, '..');
 const configPath = path.join(rootDir, 'frontend', 'config.js');
 
 // Always generate config.js so the API base URL reflects the environment
-const apiUrl = process.env.API_BASE_URL || 'https://your-api-endpoint';
+const apiUrl = process.env.API_BASE_URL || 'https://i5x97gj43e.execute-api.ca-central-1.amazonaws.com/prod';
 const content = `export const API_BASE_URL = "${apiUrl}";\n`;
 fs.writeFileSync(configPath, content);
 console.log(`Generated ${configPath} with API_BASE_URL=${apiUrl}`);


### PR DESCRIPTION
## Summary
- set API base URL to `https://i5x97gj43e.execute-api.ca-central-1.amazonaws.com/prod`
- update local dev server default
- update README example
- remove config example file

## Testing
- `npm install` in `backend`
- `CI=true npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_684c659822c483319f7cb85e352dae4d