### PR TITLE
Fix Node runtime doc mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Below is a screenshot showing the CloudWatch Dashboard and alarm configuration l
 
 All AWS Lambda source code is included in the [`backend/`](./backend/) folder.
 
-- **Language:** Node.js 20.x (uses AWS SDK v3, native `fetch()`)
+- **Language:** Node.js 18.x (uses AWS SDK v3, native `fetch()`)
 - **Endpoints handled:**
   - `/geo/direct` – City autocomplete (OpenWeatherMap API)
   - `/geo/reverse` – Reverse geocoding (coordinates → city)
@@ -143,7 +143,7 @@ AirCare/
 
 ### Local setup
 
-1. Install **Node.js 20** or newer.
+1. Install **Node.js 18** or newer.
 2. Clone this repository and install the backend dependencies:
    ```bash
    git clone https://github.com/carmelo0511/AirCare.git

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,7 +14,7 @@
   "author": "Bryan Nakache",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=18"
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.828.0",


### PR DESCRIPTION
## Summary
- clarify Node 18 requirement in package.json
- document Node.js 18 in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c6824c9a88331a683c264bb42ddac