### PR TITLE
Fix Terraform re-deploy failures

### DIFF
--- a/.github/workflows/deploy-s3.yml
+++ b/.github/workflows/deploy-s3.yml
@@ -69,6 +69,18 @@ jobs:
         working-directory: ./terraform
         run: terraform init -input=false
 
+      - name: Import existing AWS resources
+        working-directory: ./terraform
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: 'ca-central-1'
+          BUCKET_NAME: ${{ secrets.AWS_S3_BUCKET }}
+        run: |
+          terraform import aws_s3_bucket.frontend_bucket "$BUCKET_NAME" || true
+          terraform import aws_iam_role.lambda_exec lambda_exec_role || true
+          terraform import aws_dynamodb_table.history_table AirCareHistoryAQI || true
+
       - name: Terraform Apply
         working-directory: ./terraform
         env:

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "s3" {
+    bucket = "aircare-frontend-bryannakache"
+    key    = "terraform/terraform.tfstate"
+    region = "ca-central-1"
+  }
+}


### PR DESCRIPTION
## Summary
- store Terraform state in S3 so state persists across CI runs
- import any existing AWS resources before running `terraform apply`

## Testing
- `npm install --silent`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684cd3402b888331b0d4f65ff9e6f274