### PR TITLE
Refactor backend helpers

### DIFF
--- a/backend/utils.js
+++ b/backend/utils.js
@@ -1,0 +1,40 @@
+const ADVICE_MAP = {
+  1: "Good quality",
+  2: "Acceptable quality",
+  3: "Increased sensitivity",
+  4: "High pollution",
+  5: "Dangerous for health",
+};
+
+function getAdvice(aqi) {
+  return ADVICE_MAP[aqi] || "Unknown";
+}
+
+function buildResponse(statusCode, body) {
+  return {
+    statusCode,
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Headers": "Content-Type",
+      "Access-Control-Allow-Methods": "OPTIONS,GET",
+    },
+    body: JSON.stringify(body),
+  };
+}
+
+async function fetchJsonWithEnglish(url) {
+  const res = await fetch(url, { headers: { "Accept-Language": "en" } });
+  if (!res.ok) throw new Error(res.statusText);
+  return res.json();
+}
+
+function normalizeCoordinate(value) {
+  return Number(parseFloat(value).toFixed(2));
+}
+
+module.exports = {
+  getAdvice,
+  buildResponse,
+  fetchJsonWithEnglish,
+  normalizeCoordinate,
+};


### PR DESCRIPTION
## Summary
- extract common helper utilities into `utils.js`
- refactor `index.js` to use the new helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cd7c5fa8c8331b97e8a0d79544502