### PR TITLE
Improve DynamoDB schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,15 @@ This CloudFront distribution points to the S3 bucket configured to serve all HTM
 
 ## DynamoDB AQI History (NEW)
 
-AirCare **persists all AQI lookups** to a DynamoDB table (`AirCareHistoryAQI`).  
+AirCare **persists all AQI lookups** to a DynamoDB table (`AirCareHistoryAQI`).
 Each time a user requests air quality for a city or location, the following data is stored :
 - Location (`lat,lon`)
 - Timestamp (ISO format)
 - AQI value
 - Particulate data (PM2.5, PM10, etc.)
 - Health advice
+
+The table uses **`location` as the partition key** and `timestamp` as the sort key so history lookups are efficient by location and ordered by time.
 
 A dedicated endpoint (`/history`) allows the frontend to **display the full AQI history** for any location.  
 This enables analytics, trends, and potential dashboards (QuickSight integration is the next step).

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -147,7 +147,13 @@ resource "aws_lambda_permission" "apigw_lambda" {
 resource "aws_dynamodb_table" "history_table" {
   name         = var.dynamodb_table_name
   billing_mode = "PAY_PER_REQUEST"
-  hash_key     = "timestamp"
+  hash_key     = "location"
+  range_key    = "timestamp"
+
+  attribute {
+    name = "location"
+    type = "S"
+  }
 
   attribute {
     name = "timestamp"


### PR DESCRIPTION
## Summary
- fix Terraform to use `location` as partition key and `timestamp` as sort key
- document DynamoDB key design in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684ce0e60d8c8331bffde0d6f350a135