### PR TITLE
Fix Terraform CI secrets

### DIFF
--- a/.github/workflows/deploy-s3.yml
+++ b/.github/workflows/deploy-s3.yml
@@ -71,6 +71,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: 'ca-central-1'
+          TF_VAR_openweather_api_key: ${{ secrets.OPENWEATHER_APIKEY }}
         run: terraform init -input=false
 
       - name: Import existing AWS resources
@@ -81,6 +82,7 @@ jobs:
           AWS_REGION: 'ca-central-1'
           BUCKET_NAME: ${{ secrets.AWS_S3_BUCKET }}
           LAMBDA_NAME: ${{ secrets.LAMBDA_FUNCTION_NAME }}
+          TF_VAR_openweather_api_key: ${{ secrets.OPENWEATHER_APIKEY }}
         run: |
           terraform import aws_s3_bucket.frontend_bucket "$BUCKET_NAME" || true
           terraform import aws_iam_role.lambda_exec lambda_exec_role || true
@@ -93,6 +95,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: 'ca-central-1'
+          TF_VAR_openweather_api_key: ${{ secrets.OPENWEATHER_APIKEY }}
         run: terraform apply -auto-approve
 
       - name: Deploy Lambda function

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,17 +83,23 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: 'ca-central-1'
+          TF_VAR_openweather_api_key: ${{ secrets.OPENWEATHER_APIKEY }}
         run: terraform init -input=false
 
       - name: 🔄 Terraform Import Resources (idempotent)
         working-directory: ./terraform
+        env:
+          TF_VAR_openweather_api_key: ${{ secrets.OPENWEATHER_APIKEY }}
         run: |
           terraform import aws_s3_bucket.frontend_bucket "${{ secrets.AWS_S3_BUCKET }}" || true
           terraform import aws_iam_role.lambda_exec lambda_exec_role || true
           terraform import aws_dynamodb_table.history_table AirCareHistoryAQI || true
+          terraform import aws_lambda_function.aircare_backend "${{ secrets.LAMBDA_FUNCTION_NAME }}" || true
 
       - name: 🚀 Terraform Apply
         working-directory: ./terraform
+        env:
+          TF_VAR_openweather_api_key: ${{ secrets.OPENWEATHER_APIKEY }}
         run: terraform apply -auto-approve
 
       - name: 🚀 Deploy Lambda function

--- a/README.md
+++ b/README.md
@@ -223,6 +223,10 @@ terraform state list
 
 Ensure a `lambda.zip` exists in the repository root before running Terraform commands.
 
+For the CI/CD pipeline to succeed, set an `OPENWEATHER_APIKEY` secret in your
+GitHub repository. This secret provides the API key required by Terraform and
+the Lambda function.
+
 
 ---
 


### PR DESCRIPTION
## Summary
- set OPENWEATHER_APIKEY secret when running Terraform
- import existing Lambda in deploy workflow
- document required OPENWEATHER_APIKEY secret

## Testing
- `npm ci`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684ce0db08848331b20e9d7827803383