### PR TITLE
Add Terraform validation workflow and fix configuration

### DIFF
--- a/.github/workflows/terraform-test.yml
+++ b/.github/workflows/terraform-test.yml
@@ -1,0 +1,23 @@
+name: Terraform CI
+
+on:
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v2
+      - name: Terraform Format Check
+        working-directory: ./terraform
+        run: terraform fmt -check -recursive
+      - name: Terraform Init
+        working-directory: ./terraform
+        run: terraform init -backend=false
+      - name: Create dummy lambda zip
+        run: zip -j lambda.zip README.md
+      - name: Terraform Validate
+        working-directory: ./terraform
+        run: terraform validate

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -26,7 +26,7 @@ resource "aws_s3_bucket_policy" "frontend_policy" {
         Principal = {
           AWS = aws_cloudfront_origin_access_identity.oai.iam_arn
         },
-        Action = "s3:GetObject",
+        Action   = "s3:GetObject",
         Resource = "${aws_s3_bucket.frontend_bucket.arn}/*"
       }
     ]
@@ -56,8 +56,8 @@ resource "aws_iam_role" "lambda_exec" {
 }
 
 resource "aws_iam_role_policy" "lambda_logs" {
-  name   = "lambda-logs-policy"
-  role   = aws_iam_role.lambda_exec.id
+  name = "lambda-logs-policy"
+  role = aws_iam_role.lambda_exec.id
   policy = jsonencode({
     Version = "2012-10-17",
     Statement = [
@@ -129,6 +129,7 @@ resource "aws_api_gateway_deployment" "aircare_deployment" {
     aws_api_gateway_integration.history,
     aws_api_gateway_method.history
   ]
+}
 
 resource "aws_api_gateway_stage" "prod" {
   stage_name    = var.stage_name
@@ -203,10 +204,6 @@ resource "aws_cloudfront_distribution" "aircare_distribution" {
   tags = {
     Project = "AirCare"
   }
-}
-resource "aws_cloudfront_distribution" "invalidate" {
-  distribution_id = aws_cloudfront_distribution.aircare_distribution.id
-  paths           = ["/*"]
 }
 
 resource "aws_api_gateway_resource" "air_resource" {


### PR DESCRIPTION
## Summary
- fix Terraform syntax and remove unused CloudFront invalidation block
- add GitHub Actions workflow to run Terraform fmt and validate on pull requests

## Testing
- `npm test --silent`
- `terraform init -backend=false -upgrade`
- `terraform validate`

------
https://chatgpt.com/codex/tasks/task_e_684ce023a2108331b8caeddfc0607b1a