### PR TITLE
Fix Terraform deployment block

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -131,8 +131,6 @@ resource "aws_api_gateway_deployment" "aircare_deployment" {
   ]
 }
 
-}
-
 resource "aws_api_gateway_stage" "prod" {
   stage_name    = var.stage_name
   rest_api_id   = aws_api_gateway_rest_api.aircare_api.id


### PR DESCRIPTION
## Summary
- remove extraneous closing brace in `terraform/main.tf`

## Testing
- `terraform init -backend=false`
- `terraform validate`

------
https://chatgpt.com/codex/tasks/task_e_684ce43867308331b1db03f9cd50c3aa