### PR TITLE
Fix deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,26 @@ jobs:
       - name: 📦 Checkout repository
         uses: actions/checkout@v4
 
+      - name: 🔒 Verify required secrets
+        run: |
+          missing=false
+          for var in AWS_S3_BUCKET AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY CLOUDFRONT_DIST_ID LAMBDA_FUNCTION_NAME OPENWEATHER_APIKEY; do
+            if [ -z "${!var}" ]; then
+              echo "::error::$var secret not set"
+              missing=true
+            fi
+          done
+          if [ "$missing" = true ]; then
+            exit 1
+          fi
+        env:
+          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          CLOUDFRONT_DIST_ID: ${{ secrets.CLOUDFRONT_DIST_ID }}
+          LAMBDA_FUNCTION_NAME: ${{ secrets.LAMBDA_FUNCTION_NAME }}
+          OPENWEATHER_APIKEY: ${{ secrets.OPENWEATHER_APIKEY }}
+
       - name: ⚙️ Set up Node.js
         uses: actions/setup-node@v4
         with:

--- a/README.md
+++ b/README.md
@@ -236,9 +236,15 @@ terraform state list
 
 Ensure a `lambda.zip` exists in the repository root before running Terraform commands.
 
-For the CI/CD pipeline to succeed, set an `OPENWEATHER_APIKEY` secret in your
-GitHub repository. This secret provides the API key required by Terraform and
-the Lambda function.
+For the CI/CD pipeline to succeed, you must configure several secrets in your
+GitHub repository. These are consumed by the deploy workflow:
+
+- `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` – credentials for deploying
+  infrastructure and uploading the Lambda archive.
+- `AWS_S3_BUCKET` – destination S3 bucket for the frontend.
+- `CLOUDFRONT_DIST_ID` – distribution to invalidate after an upload.
+- `LAMBDA_FUNCTION_NAME` – name of the backend Lambda function.
+- `OPENWEATHER_APIKEY` – API key passed to Terraform and the Lambda runtime.
 
 
 ---


### PR DESCRIPTION
## Summary
- check for missing required secrets before deploy
- document all necessary GitHub secrets

## Testing
- `npm test --silent --prefix backend`
- `npm run test:e2e --prefix frontend`
- `terraform -chdir=terraform fmt -check -recursive`
- `terraform -chdir=terraform validate`

------
https://chatgpt.com/codex/tasks/task_e_684ce850a2dc8331939164748b70fc2c