### PR TITLE
Fix Lambda API key env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,9 +158,12 @@ AirCare/
    cd AirCare/backend
    npm install
    ```
-3. Set your OpenWeatherMap API key in the `OPENWEATHER_APIKEY` environment variable:
+3. Set your OpenWeatherMap API key in the `OPENWEATHER_APIKEY` environment variable
+   (or `API_KEY` if deploying via Terraform):
    ```bash
    export OPENWEATHER_APIKEY=your_api_key
+   # or
+   export API_KEY=your_api_key
    ```
 4. (Optional) Set the DynamoDB table name used by the Lambda via `TABLE_NAME`.
    If not set, it defaults to **AirCareHistoryAQI**:

--- a/backend/index.js
+++ b/backend/index.js
@@ -159,9 +159,10 @@ async function handleHistory(params) {
 exports.handler = async (event) => {
   console.log("📥 Event raw:", JSON.stringify(event));
 
-  const APIKEY = process.env.OPENWEATHER_APIKEY;
+  // Support both local (OPENWEATHER_APIKEY) and Terraform (API_KEY) env vars
+  const APIKEY = process.env.OPENWEATHER_APIKEY || process.env.API_KEY;
   if (!APIKEY) {
-    return buildResponse(500, { error: "Missing OPENWEATHER_APIKEY" });
+    return buildResponse(500, { error: "Missing OPENWEATHER_APIKEY/API_KEY" });
   }
 
   const path = event.resource || event.requestContext?.http?.path || event.path;


### PR DESCRIPTION
## Summary
- support both `OPENWEATHER_APIKEY` and `API_KEY` in the Lambda
- document Terraform `API_KEY` env var usage in README

## Testing
- `npm test --silent` in `backend`
- `npm run test:e2e --silent` in `frontend`
- ❌ `terraform fmt -check -recursive` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cea14125c8331a848440ecde5489d