### PR TITLE
Add best practice for existing Lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,13 @@ terraform state list
 
 Ensure a `lambda.zip` exists in the repository root before running Terraform commands.
 
+If the backend Lambda already exists in your AWS account, import it into the Terraform state before applying. This avoids `ResourceConflictException` errors:
+
+```bash
+terraform import aws_lambda_function.aircare_backend <function_arn>
+```
+
+
 For the CI/CD pipeline to succeed, you must configure several secrets in your
 GitHub repository. These are consumed by the deploy workflow:
 


### PR DESCRIPTION
## Summary
- document how to import an existing Lambda to avoid `ResourceConflictException`

## Testing
- `npm test --silent --prefix backend`
- `terraform fmt -check -recursive terraform`
- `terraform init -backend=false`
- `terraform validate`


------
https://chatgpt.com/codex/tasks/task_e_684cf05db20c83319f7d172c47d01dd9