### PR TITLE
Fix lambda API key retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,11 +159,14 @@ AirCare/
    npm install
    ```
 3. Set your OpenWeatherMap API key in the `OPENWEATHER_APIKEY` environment variable
-   (or `API_KEY` if deploying via Terraform):
+   (or `API_KEY` if deploying via Terraform). `OPENWEATHER_API_KEY` is also
+   supported for convenience:
    ```bash
    export OPENWEATHER_APIKEY=your_api_key
    # or
    export API_KEY=your_api_key
+   # or
+   export OPENWEATHER_API_KEY=your_api_key
    ```
 4. (Optional) Set the DynamoDB table name used by the Lambda via `TABLE_NAME`.
    If not set, it defaults to **AirCareHistoryAQI**:

--- a/backend/utils.js
+++ b/backend/utils.js
@@ -34,7 +34,11 @@ function normalizeCoordinate(value) {
 
 // Retrieve the OpenWeatherMap API key from environment variables
 function getApiKey() {
-  return process.env.OPENWEATHER_APIKEY || process.env.API_KEY;
+  return (
+    process.env.OPENWEATHER_APIKEY ||
+    process.env.API_KEY ||
+    process.env.OPENWEATHER_API_KEY
+  );
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary
- handle `OPENWEATHER_API_KEY` as valid environment variable
- document alternate variable in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684cf1f681448331a0a14078d3159c91