### PR TITLE
Improve lambda API key error

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -163,7 +163,9 @@ exports.handler = async (event) => {
   // Retrieve API key from environment variables
   const APIKEY = getApiKey();
   if (!APIKEY) {
-    return buildResponse(500, { error: "Missing OPENWEATHER_APIKEY/API_KEY" });
+    return buildResponse(500, {
+      error: "Missing OPENWEATHER_APIKEY/OPENWEATHER_API_KEY/API_KEY",
+    });
   }
 
   const path = event.resource || event.requestContext?.http?.path || event.path;


### PR DESCRIPTION
## Summary
- clarify environment variable names in Lambda error message

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_684d83ed0a9c8331b3a7ebe8dcbf240c