### PR TITLE
Fix CI to create lockfile before npm ci

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,7 +50,9 @@ jobs:
           npm test --silent
 
       - name: 📁 Install frontend dependencies
-        run: npm ci --prefix frontend
+        run: |
+          npm install --prefix frontend
+          npm ci --prefix frontend
       - name: 🧪 Run frontend e2e tests
         run: npm run test:e2e --prefix frontend
 


### PR DESCRIPTION
## Summary
- ensure `npm ci --prefix frontend` succeeds by first generating a lockfile

## Testing
- `npm ci --prefix backend`
- `npm test --silent --prefix backend`
- `npm install --prefix frontend`
- `npm ci --prefix frontend`
- `npm run test:e2e --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_684d83e11d8c8331944cdf8f79e9b9a0