### PR TITLE
Enhance dev server config generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,8 @@ AirCare/
    `frontend/cognito-config.js`.
 8. Serve the frontend locally from the project root. The helper script below
    (re)generates `frontend/config.js` every time so the API endpoint matches
-   the `API_BASE_URL` environment variable:
+   the `API_BASE_URL` environment variable. It also writes
+   `frontend/cognito-config.js` when the Cognito variables are present:
    ```bash
    node scripts/dev-server.js
    ```

--- a/scripts/dev-server.js
+++ b/scripts/dev-server.js
@@ -4,11 +4,28 @@ const path = require('path');
 
 const rootDir = path.join(__dirname, '..');
 const configPath = path.join(rootDir, 'frontend', 'config.js');
+const cognitoConfigPath = path.join(rootDir, 'frontend', 'cognito-config.js');
 
 // Always generate config.js so the API base URL reflects the environment
 const apiUrl = process.env.API_BASE_URL || 'https://i5x97gj43e.execute-api.ca-central-1.amazonaws.com/prod';
 const content = `export const API_BASE_URL = "${apiUrl}";\n`;
 fs.writeFileSync(configPath, content);
 console.log(`Generated ${configPath} with API_BASE_URL=${apiUrl}`);
+
+// Generate Cognito configuration if environment variables are provided
+const {
+  COGNITO_REGION,
+  COGNITO_USER_POOL_ID,
+  COGNITO_USER_POOL_CLIENT_ID,
+  COGNITO_DOMAIN
+} = process.env;
+
+if (COGNITO_REGION && COGNITO_USER_POOL_ID && COGNITO_USER_POOL_CLIENT_ID && COGNITO_DOMAIN) {
+  const cognitoContent = `export const COGNITO_CONFIG = {\n  Auth: {\n    region: "${COGNITO_REGION}",\n    userPoolId: "${COGNITO_USER_POOL_ID}",\n    userPoolWebClientId: "${COGNITO_USER_POOL_CLIENT_ID}",\n    oauth: {\n      domain: "${COGNITO_DOMAIN}",\n      scope: ["openid", "email"],\n      redirectSignIn: window.location.origin,\n      redirectSignOut: window.location.origin,\n      responseType: "code"\n    }\n  }\n};\n`;
+  fs.writeFileSync(cognitoConfigPath, cognitoContent);
+  console.log(`Generated ${cognitoConfigPath}`);
+} else {
+  console.warn('Cognito environment variables not fully set; skipping cognito-config.js generation.');
+}
 
 execSync('npx --yes http-server frontend -c-1', { stdio: 'inherit', cwd: rootDir });


### PR DESCRIPTION
## Summary
- generate `cognito-config.js` automatically in `dev-server.js`
- document the new behavior in README

## Testing
- `npm test --prefix backend`
- `npm run test:e2e --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_684d842b2a9c8331bd23e29b1dcc1ce0