### PR TITLE
Improve S3 bucket security

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -12,6 +12,16 @@ resource "aws_s3_bucket" "frontend_bucket" {
   }
 }
 
+resource "aws_s3_bucket_server_side_encryption_configuration" "frontend_bucket" {
+  bucket = aws_s3_bucket.frontend_bucket.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
 resource "aws_cloudfront_origin_access_identity" "oai" {
   comment = "AirCare OAI"
 }


### PR DESCRIPTION
## Summary
- add dedicated encryption resource to secure the frontend bucket

## Testing
- `terraform init -backend=false`
- `terraform validate`

------
https://chatgpt.com/codex/tasks/task_e_684d99b5bc60833194666a915ca381b9