### PR TITLE
Align Node version for Lambda CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,7 +37,7 @@ jobs:
       - name: ⚙️ Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '18'
 
       - name: 📁 Install backend dependencies
         run: |

--- a/.github/workflows/terraform-test.yml
+++ b/.github/workflows/terraform-test.yml
@@ -11,7 +11,7 @@ jobs:
       - name: ⚙️ Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '18'
       - name: 📁 Install backend dependencies
         run: |
           cd backend


### PR DESCRIPTION
## Summary
- use Node.js 18 in GitHub Actions workflows to match Lambda runtime

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684d9c84cf688331afb4a8fe9e002d9b