### PR TITLE
Handle missing config for dev scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,9 @@ AirCare/
    ```bash
    npm test
    ```
-6. Generate the frontend configuration files from the provided samples:
+6. Generate the frontend configuration files from the provided samples. If the
+   required environment variables are not set, the scripts will copy the sample
+   files so the app can still run with placeholder settings:
    ```bash
    API_BASE_URL=https://i5x97gj43e.execute-api.ca-central-1.amazonaws.com/prod node scripts/set-api-url.js
    COGNITO_REGION=your-region \
@@ -189,7 +191,7 @@ AirCare/
    COGNITO_DOMAIN=your-domain.auth.region.amazoncognito.com \
    node scripts/set-cognito-config.js
    ```
-   These scripts read the environment variables above and create `frontend/config.js` and `frontend/cognito-config.js`.
+   These scripts read the environment variables above and create `frontend/config.js` and `frontend/cognito-config.js`. If a variable is missing, the corresponding sample file is copied instead.
    Make sure the **Cognito domain** and callback URLs are correctly configured
    in the AWS console. If they don't match your site URL, the Hosted UI shows
    "Something went wrong. An error was encountered with the requested page.".

--- a/scripts/set-api-url.js
+++ b/scripts/set-api-url.js
@@ -2,12 +2,18 @@ const fs = require('fs');
 const path = require('path');
 
 const apiUrl = process.env.API_BASE_URL;
-if (!apiUrl) {
-  console.error('Error: API_BASE_URL environment variable is not set.');
-  process.exit(1);
-}
 
 const configPath = path.join(__dirname, '..', 'frontend', 'config.js');
+if (!apiUrl) {
+  // Fallback to the sample configuration when the environment variable is
+  // missing so the frontend still loads with placeholder values.
+  const samplePath = path.join(__dirname, '..', 'frontend', 'config.sample.js');
+  fs.copyFileSync(samplePath, configPath);
+  console.warn(
+    'API_BASE_URL not set. Copied config.sample.js to config.js instead.'
+  );
+  process.exit(0);
+}
 const content = `export const API_BASE_URL = "${apiUrl}";\n`;
 fs.writeFileSync(configPath, content);
 console.log(`Updated ${configPath} with API_BASE_URL=${apiUrl}`);

--- a/scripts/set-cognito-config.js
+++ b/scripts/set-cognito-config.js
@@ -1,14 +1,31 @@
 const fs = require('fs');
 const path = require('path');
 
-const { COGNITO_REGION, COGNITO_USER_POOL_ID, COGNITO_USER_POOL_CLIENT_ID, COGNITO_DOMAIN } = process.env;
-
-if (!COGNITO_REGION || !COGNITO_USER_POOL_ID || !COGNITO_USER_POOL_CLIENT_ID || !COGNITO_DOMAIN) {
-  console.error('Error: Cognito environment variables not fully set.');
-  process.exit(1);
-}
+const {
+  COGNITO_REGION,
+  COGNITO_USER_POOL_ID,
+  COGNITO_USER_POOL_CLIENT_ID,
+  COGNITO_DOMAIN
+} = process.env;
 
 const configPath = path.join(__dirname, '..', 'frontend', 'cognito-config.js');
+
+if (!COGNITO_REGION || !COGNITO_USER_POOL_ID || !COGNITO_USER_POOL_CLIENT_ID || !COGNITO_DOMAIN) {
+  // When variables are missing, copy the sample configuration so the
+  // application can still run (authentication will be disabled).
+  const samplePath = path.join(
+    __dirname,
+    '..',
+    'frontend',
+    'cognito-config.sample.js'
+  );
+  fs.copyFileSync(samplePath, configPath);
+  console.warn(
+    'Cognito environment variables not fully set. Copied sample configuration.'
+  );
+  process.exit(0);
+}
+
 const content = `export const COGNITO_CONFIG = {
   Auth: {
     region: "${COGNITO_REGION}",


### PR DESCRIPTION
## Summary
- make `set-api-url.js` copy `config.sample.js` when `API_BASE_URL` isn't provided
- make `set-cognito-config.js` copy `cognito-config.sample.js` when Cognito vars aren't set
- document new fallback behaviour in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684d9cb22bd0833195f1ccc693ca6867