### PR TITLE
Fix terraform import env vars in CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -99,13 +99,17 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: 'ca-central-1'
+          AWS_DEFAULT_REGION: 'ca-central-1'
           TF_VAR_openweather_api_key: ${{ secrets.OPENWEATHER_APIKEY }}
+          S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+          LAMBDA_FUNCTION_NAME: ${{ secrets.LAMBDA_FUNCTION_NAME }}
+          CLOUDFRONT_DIST_ID: ${{ secrets.CLOUDFRONT_DIST_ID }}
         run: |
-          terraform import aws_s3_bucket.frontend_bucket "${{ secrets.AWS_S3_BUCKET }}" || true
+          terraform import aws_s3_bucket.frontend_bucket "$S3_BUCKET" || true
           terraform import aws_iam_role.lambda_exec lambda_exec_role || true
           terraform import aws_dynamodb_table.history_table AirCareHistoryAQI || true
-          terraform import aws_lambda_function.aircare_backend "${{ secrets.LAMBDA_FUNCTION_NAME }}" || true
-          terraform import aws_cloudfront_distribution.aircare_distribution "${{ secrets.CLOUDFRONT_DIST_ID }}" || true
+          terraform import aws_lambda_function.aircare_backend "$LAMBDA_FUNCTION_NAME" || true
+          terraform import aws_cloudfront_distribution.aircare_distribution "$CLOUDFRONT_DIST_ID" || true
 
       - name: 🚀 Terraform Apply
         working-directory: ./terraform


### PR DESCRIPTION
## Summary
- expand Terraform import step to set AWS_DEFAULT_REGION
- export secrets as env vars for imports

## Testing
- `npm ci`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684d9e836d5c8331b904282a6da701d7