### PR TITLE
Improve CI with lambda zip check

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,6 +73,14 @@ jobs:
           zip -r ../lambda.zip . -x "*.git*" "*.zip"
           cd ..
 
+      - name: 🔍 Verify Lambda package
+        run: |
+          if [ ! -s lambda.zip ]; then
+            echo "lambda.zip not found or empty" >&2
+            exit 1
+          fi
+          ls -lh lambda.zip
+
       - name: 🏗️ Set up Terraform
         uses: hashicorp/setup-terraform@v2
 
@@ -117,6 +125,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: 'ca-central-1'
+          AWS_DEFAULT_REGION: 'ca-central-1'
           TF_VAR_openweather_api_key: ${{ secrets.OPENWEATHER_APIKEY }}
         run: terraform apply -auto-approve
 


### PR DESCRIPTION
## Summary
- verify lambda.zip exists in deploy workflow before terraform apply
- set AWS_DEFAULT_REGION for terraform apply

## Testing
- `npm ci --silent`
- `npm test --silent`
- `terraform fmt -check -recursive`
- `terraform init -backend=false`
- `terraform validate`

------
https://chatgpt.com/codex/tasks/task_e_684da206a3d8833199694fd09d73adae