### PR TITLE
Stop Lambda creation during Terraform apply

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -116,7 +116,6 @@ jobs:
           terraform import aws_s3_bucket.frontend_bucket "$S3_BUCKET" || true
           terraform import aws_iam_role.lambda_exec lambda_exec_role || true
           terraform import aws_dynamodb_table.history_table AirCareHistoryAQI || true
-          terraform import aws_lambda_function.aircare_backend "$LAMBDA_FUNCTION_NAME" || true
           terraform import aws_cloudfront_distribution.aircare_distribution "$CLOUDFRONT_DIST_ID" || true
 
       - name: 🚀 Terraform Apply

--- a/README.md
+++ b/README.md
@@ -240,10 +240,9 @@ terraform state list
 
 Ensure a `lambda.zip` exists in the repository root before running Terraform commands.
 
-If the backend Lambda already exists in your AWS account, import it into the Terraform state before applying. This avoids `ResourceConflictException` errors:
+The backend Lambda function is treated as an external resource. Terraform accesses it via a data source, so no import step is necessary:
 
 ```bash
-terraform import aws_lambda_function.aircare_backend <function_name>
 terraform import aws_cloudfront_distribution.aircare_distribution <distribution_id>
 ```
 

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -3,7 +3,7 @@ output "cloudfront_url" {
 }
 
 output "lambda_function_name" {
-  value = aws_lambda_function.aircare_backend.function_name
+  value = data.aws_lambda_function.aircare_backend.function_name
 }
 
 output "api_gateway_url" {


### PR DESCRIPTION
## Summary
- treat Lambda as an external resource
- remove Lambda import step from CI workflow
- update docs to reflect data-source approach

## Testing
- `npm test --silent`
- `terraform fmt -check -recursive`
- `terraform init -backend=false`
- `terraform validate`

------
https://chatgpt.com/codex/tasks/task_e_684da49b45248331a608140fbfa479e8