### PR TITLE
Fix Terraform pipeline imports

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -117,6 +117,8 @@ jobs:
           terraform import aws_iam_role.lambda_exec lambda_exec_role || true
           terraform import aws_dynamodb_table.history_table AirCareHistoryAQI || true
           terraform import aws_cloudfront_distribution.aircare_distribution "$CLOUDFRONT_DIST_ID" || true
+          terraform import aws_lambda_permission.apigw_lambda "$LAMBDA_FUNCTION_NAME/AllowAPIGatewayInvoke-v2" || true
+          terraform import aws_cloudwatch_log_group.lambda_logs "/aws/lambda/$LAMBDA_FUNCTION_NAME" || true
 
       - name: 🚀 Terraform Apply
         working-directory: ./terraform


### PR DESCRIPTION
## Summary
- import Lambda permission and CloudWatch log group during deploy workflow

## Testing
- `npm ci`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684da79a7d08833196f437b0a69627ee