### PR TITLE
Fix Lambda deploy pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
       - name: 🔒 Verify required secrets
         run: |
           missing=false
-          for var in AWS_S3_BUCKET AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY CLOUDFRONT_DIST_ID LAMBDA_FUNCTION_NAME OPENWEATHER_APIKEY; do
+          for var in AWS_S3_BUCKET AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY CLOUDFRONT_DIST_ID OPENWEATHER_APIKEY; do
             if [ -z "${!var}" ]; then
               echo "::error::$var secret not set"
               missing=true
@@ -31,7 +31,6 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           CLOUDFRONT_DIST_ID: ${{ secrets.CLOUDFRONT_DIST_ID }}
-          LAMBDA_FUNCTION_NAME: ${{ secrets.LAMBDA_FUNCTION_NAME }}
           OPENWEATHER_APIKEY: ${{ secrets.OPENWEATHER_APIKEY }}
 
       - name: ☁️ Configure AWS credentials
@@ -122,16 +121,19 @@ jobs:
           echo "table=${table}" >> "$GITHUB_OUTPUT"
           role=$(aws iam get-role --role-name lambda_exec_role --query 'Role.Arn' --output text)
           echo "role=${role}" >> "$GITHUB_OUTPUT"
+          function_name=$(grep lambda_function_name terraform/terraform.tfvars | awk '{print $3}' | tr -d '"')
+          echo "function_name=${function_name}" >> "$GITHUB_OUTPUT"
 
       - name: 🚀 Deploy Lambda function
         run: |
-          if aws lambda get-function --function-name ${{ secrets.LAMBDA_FUNCTION_NAME }} >/dev/null 2>&1; then
+          fname="${{ steps.infra.outputs.function_name }}"
+          if aws lambda get-function --function-name "$fname" >/dev/null 2>&1; then
             aws lambda update-function-code \
-              --function-name ${{ secrets.LAMBDA_FUNCTION_NAME }} \
+              --function-name "$fname" \
               --zip-file fileb://lambda.zip
           else
             aws lambda create-function \
-              --function-name ${{ secrets.LAMBDA_FUNCTION_NAME }} \
+              --function-name "$fname" \
               --runtime nodejs18.x \
               --role ${{ steps.infra.outputs.role }} \
               --handler index.handler \

--- a/README.md
+++ b/README.md
@@ -255,8 +255,10 @@ GitHub repository. These are consumed by the deploy workflow:
 - `AWS_S3_BUCKET` – destination S3 bucket for the frontend.
 - `CLOUDFRONT_DIST_ID` – ID of the CloudFront distribution to import and
   invalidate after each upload.
-- `LAMBDA_FUNCTION_NAME` – name of the backend Lambda function.
 - `OPENWEATHER_APIKEY` – API key passed to Terraform and the Lambda runtime.
+
+The name of the Lambda function itself is defined in `terraform/terraform.tfvars`
+under the `lambda_function_name` variable, so no additional secret is required.
 
 
 ---


### PR DESCRIPTION
## Summary
- deploy workflow no longer requires a `LAMBDA_FUNCTION_NAME` secret
- derive the Lambda function name from `terraform.tfvars`
- document that Lambda function name comes from Terraform variables

## Testing
- `npm test --silent`
- `npm prune --omit=dev`
- `terraform fmt -check -recursive`
- `terraform init -backend=false`
- `terraform validate`

------
https://chatgpt.com/codex/tasks/task_e_684dbc8b140c83318b76c2815f502b6e