### PR TITLE
Fix deploy workflow table output

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -117,7 +117,7 @@ jobs:
           api_id=$(aws apigateway get-rest-apis --query "items[?name=='AirCare API'].id" --output text)
           api="https://${api_id}.execute-api.ca-central-1.amazonaws.com/prod"
           echo "api=${api}" >> "$GITHUB_OUTPUT"
-          table=$(grep dynamodb_table_name terraform/terraform.tfvars | awk '{print $3}')
+          table=$(grep dynamodb_table_name terraform/terraform.tfvars | awk '{print $3}' | tr -d '"')
           echo "table=${table}" >> "$GITHUB_OUTPUT"
           role=$(aws iam get-role --role-name lambda_exec_role --query 'Role.Arn' --output text)
           echo "role=${role}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- strip quotes from table name extraction when deploying

## Testing
- `npm test --silent` in `backend`
- `terraform -chdir=terraform init -backend=false`
- `terraform -chdir=terraform validate`
- `terraform fmt -check -recursive terraform`

------
https://chatgpt.com/codex/tasks/task_e_684dc35189608331b59e318971151e72