### PR TITLE
Improve Terraform import step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -100,6 +100,16 @@ jobs:
           TF_VAR_openweather_api_key: ${{ secrets.OPENWEATHER_APIKEY }}
         run: terraform init -input=false
 
+      - name: 🔄 Terraform Import existing infra
+        working-directory: ./terraform
+        env:
+          TF_VAR_openweather_api_key: ${{ secrets.OPENWEATHER_APIKEY }}
+          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+        run: |
+          terraform import aws_s3_bucket.frontend_bucket $AWS_S3_BUCKET
+          terraform import aws_iam_role.lambda_exec lambda_exec_role
+          terraform import aws_dynamodb_table.history_table AirCareHistoryAQI
+
       - name: ✅ Terraform Validate
         working-directory: ./terraform
         run: terraform validate

--- a/README.md
+++ b/README.md
@@ -232,8 +232,8 @@ terraform import aws_cloudfront_distribution.aircare_distribution <distribution_
 ```
 
 If you created core resources manually (for example to bootstrap the S3 backend),
-import them before applying. Replace the placeholders below with the values from
-`terraform.tfvars`:
+the deployment workflow will import them automatically before running `terraform apply`.
+You can also run the commands below once locally if you prefer:
 
 ```bash
 terraform import aws_s3_bucket.frontend_bucket <bucket_name>


### PR DESCRIPTION
## Summary
- ensure GitHub Actions imports existing AWS resources before applying Terraform
- clarify in README that the workflow will import these resources automatically

## Testing
- `npm ci`
- `npm test`
- `terraform fmt -check -recursive` *(fails: terraform not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dcdd37e448331b90f8da02408b14a